### PR TITLE
feat: add phone contact for unavailable dates

### DIFF
--- a/components/booking/steps/ScheduleSelection.tsx
+++ b/components/booking/steps/ScheduleSelection.tsx
@@ -177,7 +177,7 @@ const ScheduleSelection: React.FC<StepProps> = ({ formData, setFormData, isActiv
       )}
       
       {/* Info Box */}
-      <InfoBox 
+      <InfoBox
         title="Important Information"
         items={[
           { title: 'Business Hours', desc: 'Open Monday through Saturday' },
@@ -186,6 +186,14 @@ const ScheduleSelection: React.FC<StepProps> = ({ formData, setFormData, isActiv
         ]}
         className="mt-6"
       />
+
+      <p className="text-sm text-gray-600 mt-4 text-center">
+        Can't find availability for your desired date? Call us at{' '}
+        <a href="tel:+13605453506" className="text-brand-600 font-medium">
+          +1 (360) 545 3506
+        </a>
+        .
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- inform users to call +1 (360) 545 3506 when no availability is found on the booking schedule

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4bd75e7008325bf34e7b18de0484f