### PR TITLE
Persist no-show fee status in booking notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,22 @@ http://localhost:3000
 - `npm run view:team` - View current team members
 - `npm run view:bookings` - View all bookings
 - `npm run seed:bookings` - Create sample bookings (development)
+- `npm run cron:no-show` - Run the daily no-show fee processor once
+
+### Automated No-Show Fee Billing
+
+The application saves each customer's card on file when they book an appointment, but Square does not automatically charge
+no-show fees. Use the cron script to process missed appointments every day:
+
+1. Ensure `.env.local` contains valid `SQUARE_ACCESS_TOKEN` and `SQUARE_ENVIRONMENT` values.
+2. Run the processor manually with `npm run cron:no-show` to verify it can authenticate.
+3. Schedule the job on your server (example runs every day at 7:00 AM):
+
+   ```cron
+   0 7 * * * cd /path/to/app && npm run cron:no-show >> logs/no-show-cron.log 2>&1
+   ```
+
+The script charges 35% of the service price for bookings marked `NO_SHOW` that are at least 24 hours old. Each successful
+charge updates the booking's seller note with the amount, currency, and payment ID so the job can safely skip bookings that
+have already been billed. Adjust `NO_SHOW_GRACE_PERIOD_HOURS` or `NO_SHOW_LOOKBACK_DAYS` in the environment if you need a
+different grace period or lookback window.

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -113,11 +113,16 @@ export async function POST(request) {
 		// Store card on file if payment token is provided
 		const storedCardId = await storeCardOnFile(customer, paymentToken);
 
-		const bookingData = {
-			locationId: defaultLocationId,
-			customerId: customer.id,
-			startAt,
-			sellerNote: storedCardId ? `Card ID: ${storedCardId}` : undefined,
+                const sellerNoteParts = [
+                        storedCardId ? `Card ID: ${storedCardId}` : null,
+                        'No-Show Fee Charged (cents): 0',
+                ].filter(Boolean);
+
+                const bookingData = {
+                        locationId: defaultLocationId,
+                        customerId: customer.id,
+                        startAt,
+                        sellerNote: sellerNoteParts.length > 0 ? sellerNoteParts.join(' | ') : undefined,
 			customerNote:
 				[
 					`Drop-off Time: ${dropOffTime}`,

--- a/app/api/cron/charge-no-show/route.ts
+++ b/app/api/cron/charge-no-show/route.ts
@@ -1,0 +1,535 @@
+'use server';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { SquareClient, SquareEnvironment } from 'square';
+import { randomUUID, createHash } from 'crypto';
+
+type MoneyLike = {
+	amount: bigint;
+	currency: string;
+};
+
+type Summary = {
+	processed: number;
+	eligible: number;
+	charged: number;
+	skipped: string[];
+	errors: string[];
+};
+
+const NO_SHOW_FEE_RATE = 0.35;
+const GRACE_PERIOD_HOURS = parseInt(process.env.NO_SHOW_GRACE_PERIOD_HOURS || '24', 10);
+const GRACE_PERIOD_MS = GRACE_PERIOD_HOURS * 60 * 60 * 1000;
+const LOOKBACK_DAYS = parseInt(process.env.NO_SHOW_LOOKBACK_DAYS || '30', 10);
+const LOOKBACK_MS = LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+
+function toBigInt(value: unknown): bigint {
+	if (typeof value === 'bigint') {
+		return value;
+	}
+	if (typeof value === 'number') {
+		return BigInt(Math.round(value));
+	}
+	if (typeof value === 'string') {
+		return BigInt(value);
+	}
+	throw new Error(`Unable to convert value "${String(value)}" to BigInt.`);
+}
+
+function getVehicleSquareEnvironment(): SquareEnvironment {
+	return process.env.SQUARE_ENVIRONMENT === 'production' ? SquareEnvironment.Production : SquareEnvironment.Sandbox;
+}
+
+function buildPaymentIdempotencyKey(bookingId: string | undefined, amount: bigint): string {
+	const base = `${bookingId || 'unknown'}-${amount.toString()}`;
+	return createHash('sha256').update(base).digest('hex').slice(0, 45);
+}
+
+function formatMoney(money: MoneyLike | null): string {
+	if (!money) {
+		return '0.00';
+	}
+	const amountNumber = Number(money.amount) / 100;
+	return `${amountNumber.toFixed(2)} ${money.currency}`;
+}
+
+function extractCardId(note: string | null | undefined): string | null {
+	const details = getSellerNoteDetails(note);
+	if (details.cardId) {
+		return details.cardId;
+	}
+	if (typeof note !== 'string') {
+		return null;
+	}
+	const match = note.match(/Card ID:\s*([\w:-]+)/i);
+	return match ? match[1] : null;
+}
+
+function getSellerNoteDetails(note: string | null | undefined) {
+	const details = {
+		cardId: null as string | null,
+		chargedCents: null as bigint | null,
+		chargedCurrency: null as string | null,
+		chargedAt: null as string | null,
+		paymentId: null as string | null,
+		otherTokens: [] as string[],
+	};
+
+	if (typeof note !== 'string' || note.trim() === '') {
+		return details;
+}
+
+	const tokens = note
+		.split('|')
+		.map((token) => token.trim())
+		.filter(Boolean);
+
+	for (const token of tokens) {
+		const [rawKey, ...rawValue] = token.split(':');
+		if (!rawKey || rawValue.length === 0) {
+			details.otherTokens.push(token);
+			continue;
+		}
+
+		const key = rawKey.trim().toLowerCase();
+		const value = rawValue.join(':').trim();
+
+		switch (key) {
+			case 'card id':
+				details.cardId = value || null;
+				break;
+			case 'no-show fee charged (cents)': {
+				const numeric = value.replace(/[^0-9-]/g, '');
+				if (numeric) {
+					try {
+						details.chargedCents = BigInt(numeric);
+					} catch {
+						details.chargedCents = null;
+					}
+				} else if (value === '0') {
+					details.chargedCents = 0n;
+				}
+				break;
+			}
+			case 'no-show fee charged currency':
+				details.chargedCurrency = value || null;
+				break;
+			case 'no-show fee charged at':
+				details.chargedAt = value || null;
+				break;
+			case 'no-show fee charged payment id':
+				details.paymentId = value || null;
+				break;
+			default:
+				details.otherTokens.push(token);
+				break;
+		}
+	}
+
+	return details;
+}
+
+function composeChargedSellerNote({
+	originalNote,
+	cardId,
+	feeMoney,
+	paymentId,
+}: {
+	originalNote: string | null | undefined;
+	cardId: string | null;
+	feeMoney: MoneyLike | null;
+	paymentId: string | null;
+}): string {
+	const details = getSellerNoteDetails(originalNote);
+	const tokens = details.otherTokens.filter(Boolean);
+
+	const resolvedCardId = cardId || details.cardId;
+	if (resolvedCardId) {
+		tokens.unshift(`Card ID: ${resolvedCardId}`);
+	}
+
+	const amountCents = feeMoney?.amount != null ? feeMoney.amount.toString() : null;
+	if (amountCents != null) {
+		tokens.push(`No-Show Fee Charged (cents): ${amountCents}`);
+	}
+
+	if (feeMoney?.currency) {
+		tokens.push(`No-Show Fee Charged Currency: ${feeMoney.currency}`);
+	} else if (details.chargedCurrency) {
+		tokens.push(`No-Show Fee Charged Currency: ${details.chargedCurrency}`);
+	}
+
+	const chargedAt = new Date().toISOString();
+	tokens.push(`No-Show Fee Charged At: ${chargedAt}`);
+
+	if (paymentId) {
+		tokens.push(`No-Show Fee Charged Payment ID: ${paymentId}`);
+	}
+
+	return tokens.join(' | ');
+}
+
+function calculateNoShowFee(serviceMoney: MoneyLike | null): MoneyLike | null {
+	if (!serviceMoney || serviceMoney.amount == null) {
+		return null;
+	}
+	const amountNumber = Number(serviceMoney.amount);
+	const feeCents = Math.round(amountNumber * NO_SHOW_FEE_RATE);
+	if (feeCents <= 0) {
+		return null;
+	}
+	return {
+		amount: BigInt(feeCents),
+		currency: serviceMoney.currency || 'USD',
+	};
+}
+
+function hasGracePeriodElapsed(booking: any): boolean {
+	if (!booking?.startAt) {
+		return false;
+	}
+	const startTime = new Date(booking.startAt).getTime();
+	if (Number.isNaN(startTime)) {
+		return false;
+	}
+	return startTime + GRACE_PERIOD_MS <= Date.now();
+}
+
+function isWithinLookback(booking: any): boolean {
+	if (!booking?.startAt) {
+		return false;
+	}
+	const startTime = new Date(booking.startAt).getTime();
+	if (Number.isNaN(startTime)) {
+		return false;
+	}
+	return startTime >= Date.now() - LOOKBACK_MS;
+}
+
+async function runNoShowFeeJob(): Promise<Summary> {
+	const accessToken = process.env.SQUARE_ACCESS_TOKEN;
+	if (!accessToken) {
+		throw new Error('SQUARE_ACCESS_TOKEN not configured.');
+	}
+
+	const client = new SquareClient({
+		token: accessToken,
+		environment: getVehicleSquareEnvironment(),
+		userAgentDetail: 'car-wash-no-show-cron-api',
+	});
+
+	const summary: Summary = {
+		processed: 0,
+		eligible: 0,
+		charged: 0,
+		skipped: [],
+		errors: [],
+	};
+
+	const variationPriceCache = new Map<string, MoneyLike>();
+
+	function logSkip(bookingId: string | null, reason: string) {
+		const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} skipped: ${reason}`;
+		summary.skipped.push(message);
+		console.log(`⚪ ${message}`);
+	}
+
+	function logError(bookingId: string | null, error: unknown) {
+		const typedError = error as any;
+		const errorsList = typedError?.errors?.map((e: any) => e?.detail).filter(Boolean);
+		const errorMessage = typedError?.message || (errorsList?.length ? errorsList.join(', ') : null) || String(error);
+		const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} failed: ${errorMessage}`;
+		summary.errors.push(message);
+		console.error(`✗ ${message}`);
+	}
+
+	async function getLocationId(): Promise<string> {
+		const response = await client.locations.list();
+		const locations = response?.locations || response?.result?.locations || [];
+		if (!locations.length) {
+			throw new Error('No Square locations available.');
+		}
+		return locations[0].id;
+	}
+
+	async function getVariationPriceMoney(variationId: string | null | undefined): Promise<MoneyLike | null> {
+		if (!variationId) {
+			return null;
+		}
+		if (variationPriceCache.has(variationId)) {
+			return variationPriceCache.get(variationId) ?? null;
+		}
+
+		const response = await client.catalog.object.get({ objectId: variationId });
+		const variation = response?.object || response?.result?.object || response?.data?.object;
+		const priceMoney = variation?.itemVariationData?.priceMoney;
+
+		if (!priceMoney || priceMoney.amount == null) {
+			throw new Error(`No price found for service variation ${variationId}.`);
+		}
+
+		const normalized: MoneyLike = {
+			amount: toBigInt(priceMoney.amount),
+			currency: priceMoney.currency || 'USD',
+		};
+		variationPriceCache.set(variationId, normalized);
+		return normalized;
+	}
+
+	async function getBookingServicePriceMoney(booking: any): Promise<MoneyLike | null> {
+		const segments = Array.isArray(booking?.appointmentSegments) ? booking.appointmentSegments : [];
+		if (!segments.length) {
+			return null;
+		}
+
+		let totalAmount = 0n;
+		let currency: string | null = null;
+
+		for (const segment of segments) {
+			const variationId = segment?.serviceVariationId;
+			if (!variationId) {
+				continue;
+			}
+			const priceMoney = await getVariationPriceMoney(variationId);
+			if (!priceMoney) {
+				continue;
+			}
+			totalAmount += priceMoney.amount;
+			currency = currency || priceMoney.currency;
+		}
+
+		if (totalAmount <= 0n) {
+			return null;
+		}
+
+		return {
+			amount: totalAmount,
+			currency: currency || 'USD',
+		};
+	}
+
+	async function markBookingCharged({
+		booking,
+		cardId,
+		feeMoney,
+		paymentId,
+	}: {
+		booking: any;
+		cardId: string | null;
+		feeMoney: MoneyLike;
+		paymentId: string | null;
+	}) {
+		const bookingId = booking?.id;
+		if (!bookingId) {
+			throw new Error('Cannot update booking without an ID.');
+		}
+
+		const sellerNote = composeChargedSellerNote({
+			originalNote: booking.sellerNote,
+			cardId,
+			feeMoney,
+			paymentId,
+		});
+
+		const bookingPayload: Record<string, unknown> = {
+			sellerNote,
+		};
+
+		if (booking?.version != null) {
+			bookingPayload.version = booking.version;
+		}
+
+		await client.bookings.update({
+			bookingId,
+			idempotencyKey: randomUUID(),
+			booking: bookingPayload,
+		});
+	}
+
+	async function chargeBooking({
+		booking,
+		cardId,
+		feeMoney,
+		locationId,
+	}: {
+		booking: any;
+		cardId: string;
+		feeMoney: MoneyLike;
+		locationId: string;
+	}) {
+		const bookingId: string | undefined = booking.id;
+		const requestBody = {
+			sourceId: cardId,
+			idempotencyKey: buildPaymentIdempotencyKey(bookingId, feeMoney.amount),
+			amountMoney: feeMoney,
+			customerId: booking.customerId || undefined,
+			locationId,
+			referenceId: bookingId || undefined,
+			note: `No-show fee for booking ${bookingId}`,
+		};
+
+		const response = await client.payments.create(requestBody);
+		const payment = response?.payment || response?.result?.payment || response?.data?.payment;
+		if (!payment) {
+			throw new Error('Payment API response did not include a payment record.');
+		}
+
+		try {
+			await markBookingCharged({ booking, cardId, feeMoney, paymentId: payment.id });
+		} catch (error) {
+			throw new Error(
+				`Charged payment ${payment.id} but failed to update booking note: ${(error as Error)?.message || error}`
+			);
+		}
+
+		console.log(`✅ Charged ${formatMoney(feeMoney)} for booking ${bookingId} (payment ${payment.id}).`);
+	}
+
+	async function processBookings() {
+		const locationId = await getLocationId();
+
+		const nowIso = new Date().toISOString();
+		const lookbackIso = new Date(Date.now() - LOOKBACK_MS).toISOString();
+
+		const bookingsApi: any = (client as any).bookings ?? (client as any).bookingsApi;
+		if (!bookingsApi?.list) {
+			throw new Error('Square bookings API client is not available.');
+		}
+
+		const bookingsPage: any = await bookingsApi.list({
+			locationId,
+			startAtMin: lookbackIso,
+			startAtMax: nowIso,
+			limit: 100,
+		});
+
+		for await (const booking of bookingsPage as any) {
+			const bookingId: string = booking?.id || 'unknown';
+			summary.processed += 1;
+
+			if (booking.status !== 'NO_SHOW') {
+				logSkip(bookingId, `status ${booking.status}`);
+				continue;
+			}
+
+			if (!isWithinLookback(booking)) {
+				logSkip(bookingId, 'outside lookback window');
+				continue;
+			}
+
+			if (!hasGracePeriodElapsed(booking)) {
+				logSkip(bookingId, `still within ${GRACE_PERIOD_HOURS}h grace period`);
+				continue;
+			}
+
+			if (!bookingId) {
+				logSkip(bookingId, 'missing booking ID');
+				continue;
+			}
+
+			const noteDetails = getSellerNoteDetails(booking.sellerNote);
+			const cardId = noteDetails.cardId || extractCardId(booking.sellerNote);
+			if (!cardId) {
+				logSkip(bookingId, 'no stored card ID found');
+				continue;
+			}
+
+			let serviceMoney: MoneyLike | null = null;
+			try {
+				serviceMoney = await getBookingServicePriceMoney(booking);
+			} catch (error) {
+				logError(bookingId, error);
+				continue;
+			}
+
+			if (!serviceMoney) {
+				logSkip(bookingId, 'no service price available');
+				continue;
+			}
+
+			const feeMoney = calculateNoShowFee(serviceMoney);
+			if (!feeMoney) {
+				logSkip(bookingId, 'no-show fee calculated as $0');
+				continue;
+			}
+
+			if (noteDetails.chargedCents != null) {
+				const recordedAmount = noteDetails.chargedCents;
+				const recordedCurrency = noteDetails.chargedCurrency || feeMoney.currency;
+				if (recordedAmount === feeMoney.amount && recordedCurrency === feeMoney.currency) {
+					logSkip(bookingId, 'no-show fee already recorded on booking');
+					continue;
+				}
+
+				if (recordedAmount > 0n) {
+					logSkip(
+						bookingId,
+						`booking seller note already shows ${formatMoney({ amount: recordedAmount, currency: recordedCurrency })}`
+					);
+					continue;
+				}
+			}
+
+			summary.eligible += 1;
+
+			try {
+				await chargeBooking({ booking, cardId, feeMoney, locationId });
+				summary.charged += 1;
+			} catch (error) {
+				logError(bookingId, error);
+			}
+		}
+	}
+
+	console.log('🚀 Starting no-show fee cron run (API invocation)...');
+	console.log(`   Grace period: ${GRACE_PERIOD_HOURS} hours | Lookback: ${LOOKBACK_DAYS} days`);
+
+	await processBookings();
+
+	console.log('––––––––––––––––––––––––––––––––––––');
+	console.log(`Processed bookings: ${summary.processed}`);
+	console.log(`Eligible for charge: ${summary.eligible}`);
+	console.log(`Charged successfully: ${summary.charged}`);
+	console.log(`Skipped: ${summary.skipped.length}`);
+	console.log(`Errors: ${summary.errors.length}`);
+
+	return summary;
+}
+
+function getCronSecret(): string | null {
+	return process.env.NO_SHOW_CRON_SECRET || process.env.CRON_SECRET || null;
+}
+
+function isAuthorized(request: NextRequest): boolean {
+	const secret = getCronSecret();
+	if (!secret) {
+		return true;
+	}
+
+	const headerSecret = request.headers.get('x-cron-secret') || request.headers.get('authorization');
+	if (headerSecret) {
+		const token = headerSecret.replace(/^Bearer\s+/i, '').trim();
+		return token === secret;
+	}
+
+	const urlSecret = request.nextUrl.searchParams.get('token') || request.nextUrl.searchParams.get('secret');
+	return urlSecret === secret;
+}
+
+export async function GET(request: NextRequest) {
+	if (!isAuthorized(request)) {
+		return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+	}
+
+	try {
+		const summary = await runNoShowFeeJob();
+		return NextResponse.json({ ok: true, summary });
+	} catch (error) {
+		console.error('No-show cron failed', error);
+		const typedError = error as any;
+		const message = typedError?.message || typedError?.toString?.() || 'Unknown error';
+		return NextResponse.json({ ok: false, error: message }, { status: 500 });
+	}
+}
+
+export const dynamic = 'force-dynamic';

--- a/app/api/cron/charge-no-show/route.ts
+++ b/app/api/cron/charge-no-show/route.ts
@@ -1,535 +1,544 @@
-'use server';
-
-import { NextRequest, NextResponse } from 'next/server';
-import { SquareClient, SquareEnvironment } from 'square';
-import { randomUUID, createHash } from 'crypto';
-
-type MoneyLike = {
-	amount: bigint;
-	currency: string;
-};
-
-type Summary = {
-	processed: number;
-	eligible: number;
-	charged: number;
-	skipped: string[];
-	errors: string[];
-};
-
-const NO_SHOW_FEE_RATE = 0.35;
-const GRACE_PERIOD_HOURS = parseInt(process.env.NO_SHOW_GRACE_PERIOD_HOURS || '24', 10);
-const GRACE_PERIOD_MS = GRACE_PERIOD_HOURS * 60 * 60 * 1000;
-const LOOKBACK_DAYS = parseInt(process.env.NO_SHOW_LOOKBACK_DAYS || '30', 10);
-const LOOKBACK_MS = LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
-
-function toBigInt(value: unknown): bigint {
-	if (typeof value === 'bigint') {
-		return value;
-	}
-	if (typeof value === 'number') {
-		return BigInt(Math.round(value));
-	}
-	if (typeof value === 'string') {
-		return BigInt(value);
-	}
-	throw new Error(`Unable to convert value "${String(value)}" to BigInt.`);
-}
-
-function getVehicleSquareEnvironment(): SquareEnvironment {
-	return process.env.SQUARE_ENVIRONMENT === 'production' ? SquareEnvironment.Production : SquareEnvironment.Sandbox;
-}
-
-function buildPaymentIdempotencyKey(bookingId: string | undefined, amount: bigint): string {
-	const base = `${bookingId || 'unknown'}-${amount.toString()}`;
-	return createHash('sha256').update(base).digest('hex').slice(0, 45);
-}
-
-function formatMoney(money: MoneyLike | null): string {
-	if (!money) {
-		return '0.00';
-	}
-	const amountNumber = Number(money.amount) / 100;
-	return `${amountNumber.toFixed(2)} ${money.currency}`;
-}
-
-function extractCardId(note: string | null | undefined): string | null {
-	const details = getSellerNoteDetails(note);
-	if (details.cardId) {
-		return details.cardId;
-	}
-	if (typeof note !== 'string') {
-		return null;
-	}
-	const match = note.match(/Card ID:\s*([\w:-]+)/i);
-	return match ? match[1] : null;
-}
-
-function getSellerNoteDetails(note: string | null | undefined) {
-	const details = {
-		cardId: null as string | null,
-		chargedCents: null as bigint | null,
-		chargedCurrency: null as string | null,
-		chargedAt: null as string | null,
-		paymentId: null as string | null,
-		otherTokens: [] as string[],
-	};
-
-	if (typeof note !== 'string' || note.trim() === '') {
-		return details;
-}
-
-	const tokens = note
-		.split('|')
-		.map((token) => token.trim())
-		.filter(Boolean);
-
-	for (const token of tokens) {
-		const [rawKey, ...rawValue] = token.split(':');
-		if (!rawKey || rawValue.length === 0) {
-			details.otherTokens.push(token);
-			continue;
-		}
-
-		const key = rawKey.trim().toLowerCase();
-		const value = rawValue.join(':').trim();
-
-		switch (key) {
-			case 'card id':
-				details.cardId = value || null;
-				break;
-			case 'no-show fee charged (cents)': {
-				const numeric = value.replace(/[^0-9-]/g, '');
-				if (numeric) {
-					try {
-						details.chargedCents = BigInt(numeric);
-					} catch {
-						details.chargedCents = null;
-					}
-				} else if (value === '0') {
-					details.chargedCents = 0n;
-				}
-				break;
-			}
-			case 'no-show fee charged currency':
-				details.chargedCurrency = value || null;
-				break;
-			case 'no-show fee charged at':
-				details.chargedAt = value || null;
-				break;
-			case 'no-show fee charged payment id':
-				details.paymentId = value || null;
-				break;
-			default:
-				details.otherTokens.push(token);
-				break;
-		}
-	}
-
-	return details;
-}
-
-function composeChargedSellerNote({
-	originalNote,
-	cardId,
-	feeMoney,
-	paymentId,
-}: {
-	originalNote: string | null | undefined;
-	cardId: string | null;
-	feeMoney: MoneyLike | null;
-	paymentId: string | null;
-}): string {
-	const details = getSellerNoteDetails(originalNote);
-	const tokens = details.otherTokens.filter(Boolean);
-
-	const resolvedCardId = cardId || details.cardId;
-	if (resolvedCardId) {
-		tokens.unshift(`Card ID: ${resolvedCardId}`);
-	}
-
-	const amountCents = feeMoney?.amount != null ? feeMoney.amount.toString() : null;
-	if (amountCents != null) {
-		tokens.push(`No-Show Fee Charged (cents): ${amountCents}`);
-	}
-
-	if (feeMoney?.currency) {
-		tokens.push(`No-Show Fee Charged Currency: ${feeMoney.currency}`);
-	} else if (details.chargedCurrency) {
-		tokens.push(`No-Show Fee Charged Currency: ${details.chargedCurrency}`);
-	}
-
-	const chargedAt = new Date().toISOString();
-	tokens.push(`No-Show Fee Charged At: ${chargedAt}`);
-
-	if (paymentId) {
-		tokens.push(`No-Show Fee Charged Payment ID: ${paymentId}`);
-	}
-
-	return tokens.join(' | ');
-}
-
-function calculateNoShowFee(serviceMoney: MoneyLike | null): MoneyLike | null {
-	if (!serviceMoney || serviceMoney.amount == null) {
-		return null;
-	}
-	const amountNumber = Number(serviceMoney.amount);
-	const feeCents = Math.round(amountNumber * NO_SHOW_FEE_RATE);
-	if (feeCents <= 0) {
-		return null;
-	}
-	return {
-		amount: BigInt(feeCents),
-		currency: serviceMoney.currency || 'USD',
-	};
-}
-
-function hasGracePeriodElapsed(booking: any): boolean {
-	if (!booking?.startAt) {
-		return false;
-	}
-	const startTime = new Date(booking.startAt).getTime();
-	if (Number.isNaN(startTime)) {
-		return false;
-	}
-	return startTime + GRACE_PERIOD_MS <= Date.now();
-}
-
-function isWithinLookback(booking: any): boolean {
-	if (!booking?.startAt) {
-		return false;
-	}
-	const startTime = new Date(booking.startAt).getTime();
-	if (Number.isNaN(startTime)) {
-		return false;
-	}
-	return startTime >= Date.now() - LOOKBACK_MS;
-}
-
-async function runNoShowFeeJob(): Promise<Summary> {
-	const accessToken = process.env.SQUARE_ACCESS_TOKEN;
-	if (!accessToken) {
-		throw new Error('SQUARE_ACCESS_TOKEN not configured.');
-	}
-
-	const client = new SquareClient({
-		token: accessToken,
-		environment: getVehicleSquareEnvironment(),
-		userAgentDetail: 'car-wash-no-show-cron-api',
-	});
-
-	const summary: Summary = {
-		processed: 0,
-		eligible: 0,
-		charged: 0,
-		skipped: [],
-		errors: [],
-	};
-
-	const variationPriceCache = new Map<string, MoneyLike>();
-
-	function logSkip(bookingId: string | null, reason: string) {
-		const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} skipped: ${reason}`;
-		summary.skipped.push(message);
-		console.log(`⚪ ${message}`);
-	}
-
-	function logError(bookingId: string | null, error: unknown) {
-		const typedError = error as any;
-		const errorsList = typedError?.errors?.map((e: any) => e?.detail).filter(Boolean);
-		const errorMessage = typedError?.message || (errorsList?.length ? errorsList.join(', ') : null) || String(error);
-		const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} failed: ${errorMessage}`;
-		summary.errors.push(message);
-		console.error(`✗ ${message}`);
-	}
-
-	async function getLocationId(): Promise<string> {
-		const response = await client.locations.list();
-		const locations = response?.locations || response?.result?.locations || [];
-		if (!locations.length) {
-			throw new Error('No Square locations available.');
-		}
-		return locations[0].id;
-	}
-
-	async function getVariationPriceMoney(variationId: string | null | undefined): Promise<MoneyLike | null> {
-		if (!variationId) {
-			return null;
-		}
-		if (variationPriceCache.has(variationId)) {
-			return variationPriceCache.get(variationId) ?? null;
-		}
-
-		const response = await client.catalog.object.get({ objectId: variationId });
-		const variation = response?.object || response?.result?.object || response?.data?.object;
-		const priceMoney = variation?.itemVariationData?.priceMoney;
-
-		if (!priceMoney || priceMoney.amount == null) {
-			throw new Error(`No price found for service variation ${variationId}.`);
-		}
-
-		const normalized: MoneyLike = {
-			amount: toBigInt(priceMoney.amount),
-			currency: priceMoney.currency || 'USD',
-		};
-		variationPriceCache.set(variationId, normalized);
-		return normalized;
-	}
-
-	async function getBookingServicePriceMoney(booking: any): Promise<MoneyLike | null> {
-		const segments = Array.isArray(booking?.appointmentSegments) ? booking.appointmentSegments : [];
-		if (!segments.length) {
-			return null;
-		}
-
-		let totalAmount = 0n;
-		let currency: string | null = null;
-
-		for (const segment of segments) {
-			const variationId = segment?.serviceVariationId;
-			if (!variationId) {
-				continue;
-			}
-			const priceMoney = await getVariationPriceMoney(variationId);
-			if (!priceMoney) {
-				continue;
-			}
-			totalAmount += priceMoney.amount;
-			currency = currency || priceMoney.currency;
-		}
-
-		if (totalAmount <= 0n) {
-			return null;
-		}
-
-		return {
-			amount: totalAmount,
-			currency: currency || 'USD',
-		};
-	}
-
-	async function markBookingCharged({
-		booking,
-		cardId,
-		feeMoney,
-		paymentId,
-	}: {
-		booking: any;
-		cardId: string | null;
-		feeMoney: MoneyLike;
-		paymentId: string | null;
-	}) {
-		const bookingId = booking?.id;
-		if (!bookingId) {
-			throw new Error('Cannot update booking without an ID.');
-		}
-
-		const sellerNote = composeChargedSellerNote({
-			originalNote: booking.sellerNote,
-			cardId,
-			feeMoney,
-			paymentId,
-		});
-
-		const bookingPayload: Record<string, unknown> = {
-			sellerNote,
-		};
-
-		if (booking?.version != null) {
-			bookingPayload.version = booking.version;
-		}
-
-		await client.bookings.update({
-			bookingId,
-			idempotencyKey: randomUUID(),
-			booking: bookingPayload,
-		});
-	}
-
-	async function chargeBooking({
-		booking,
-		cardId,
-		feeMoney,
-		locationId,
-	}: {
-		booking: any;
-		cardId: string;
-		feeMoney: MoneyLike;
-		locationId: string;
-	}) {
-		const bookingId: string | undefined = booking.id;
-		const requestBody = {
-			sourceId: cardId,
-			idempotencyKey: buildPaymentIdempotencyKey(bookingId, feeMoney.amount),
-			amountMoney: feeMoney,
-			customerId: booking.customerId || undefined,
-			locationId,
-			referenceId: bookingId || undefined,
-			note: `No-show fee for booking ${bookingId}`,
-		};
-
-		const response = await client.payments.create(requestBody);
-		const payment = response?.payment || response?.result?.payment || response?.data?.payment;
-		if (!payment) {
-			throw new Error('Payment API response did not include a payment record.');
-		}
-
-		try {
-			await markBookingCharged({ booking, cardId, feeMoney, paymentId: payment.id });
-		} catch (error) {
-			throw new Error(
-				`Charged payment ${payment.id} but failed to update booking note: ${(error as Error)?.message || error}`
-			);
-		}
-
-		console.log(`✅ Charged ${formatMoney(feeMoney)} for booking ${bookingId} (payment ${payment.id}).`);
-	}
-
-	async function processBookings() {
-		const locationId = await getLocationId();
-
-		const nowIso = new Date().toISOString();
-		const lookbackIso = new Date(Date.now() - LOOKBACK_MS).toISOString();
-
-		const bookingsApi: any = (client as any).bookings ?? (client as any).bookingsApi;
-		if (!bookingsApi?.list) {
-			throw new Error('Square bookings API client is not available.');
-		}
-
-		const bookingsPage: any = await bookingsApi.list({
-			locationId,
-			startAtMin: lookbackIso,
-			startAtMax: nowIso,
-			limit: 100,
-		});
-
-		for await (const booking of bookingsPage as any) {
-			const bookingId: string = booking?.id || 'unknown';
-			summary.processed += 1;
-
-			if (booking.status !== 'NO_SHOW') {
-				logSkip(bookingId, `status ${booking.status}`);
-				continue;
-			}
-
-			if (!isWithinLookback(booking)) {
-				logSkip(bookingId, 'outside lookback window');
-				continue;
-			}
-
-			if (!hasGracePeriodElapsed(booking)) {
-				logSkip(bookingId, `still within ${GRACE_PERIOD_HOURS}h grace period`);
-				continue;
-			}
-
-			if (!bookingId) {
-				logSkip(bookingId, 'missing booking ID');
-				continue;
-			}
-
-			const noteDetails = getSellerNoteDetails(booking.sellerNote);
-			const cardId = noteDetails.cardId || extractCardId(booking.sellerNote);
-			if (!cardId) {
-				logSkip(bookingId, 'no stored card ID found');
-				continue;
-			}
-
-			let serviceMoney: MoneyLike | null = null;
-			try {
-				serviceMoney = await getBookingServicePriceMoney(booking);
-			} catch (error) {
-				logError(bookingId, error);
-				continue;
-			}
-
-			if (!serviceMoney) {
-				logSkip(bookingId, 'no service price available');
-				continue;
-			}
-
-			const feeMoney = calculateNoShowFee(serviceMoney);
-			if (!feeMoney) {
-				logSkip(bookingId, 'no-show fee calculated as $0');
-				continue;
-			}
-
-			if (noteDetails.chargedCents != null) {
-				const recordedAmount = noteDetails.chargedCents;
-				const recordedCurrency = noteDetails.chargedCurrency || feeMoney.currency;
-				if (recordedAmount === feeMoney.amount && recordedCurrency === feeMoney.currency) {
-					logSkip(bookingId, 'no-show fee already recorded on booking');
-					continue;
-				}
-
-				if (recordedAmount > 0n) {
-					logSkip(
-						bookingId,
-						`booking seller note already shows ${formatMoney({ amount: recordedAmount, currency: recordedCurrency })}`
-					);
-					continue;
-				}
-			}
-
-			summary.eligible += 1;
-
-			try {
-				await chargeBooking({ booking, cardId, feeMoney, locationId });
-				summary.charged += 1;
-			} catch (error) {
-				logError(bookingId, error);
-			}
-		}
-	}
-
-	console.log('🚀 Starting no-show fee cron run (API invocation)...');
-	console.log(`   Grace period: ${GRACE_PERIOD_HOURS} hours | Lookback: ${LOOKBACK_DAYS} days`);
-
-	await processBookings();
-
-	console.log('––––––––––––––––––––––––––––––––––––');
-	console.log(`Processed bookings: ${summary.processed}`);
-	console.log(`Eligible for charge: ${summary.eligible}`);
-	console.log(`Charged successfully: ${summary.charged}`);
-	console.log(`Skipped: ${summary.skipped.length}`);
-	console.log(`Errors: ${summary.errors.length}`);
-
-	return summary;
-}
-
-function getCronSecret(): string | null {
-	return process.env.NO_SHOW_CRON_SECRET || process.env.CRON_SECRET || null;
-}
-
-function isAuthorized(request: NextRequest): boolean {
-	const secret = getCronSecret();
-	if (!secret) {
-		return true;
-	}
-
-	const headerSecret = request.headers.get('x-cron-secret') || request.headers.get('authorization');
-	if (headerSecret) {
-		const token = headerSecret.replace(/^Bearer\s+/i, '').trim();
-		return token === secret;
-	}
-
-	const urlSecret = request.nextUrl.searchParams.get('token') || request.nextUrl.searchParams.get('secret');
-	return urlSecret === secret;
-}
-
-export async function GET(request: NextRequest) {
-	if (!isAuthorized(request)) {
-		return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-	}
-
-	try {
-		const summary = await runNoShowFeeJob();
-		return NextResponse.json({ ok: true, summary });
-	} catch (error) {
-		console.error('No-show cron failed', error);
-		const typedError = error as any;
-		const message = typedError?.message || typedError?.toString?.() || 'Unknown error';
-		return NextResponse.json({ ok: false, error: message }, { status: 500 });
-	}
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+	return NextResponse.json(
+		{ ok: false, error: 'No-show cron is temporarily disabled.' },
+		{ status: 503 }
+	);
 }
 
 export const dynamic = 'force-dynamic';
+
+// import { NextRequest, NextResponse } from 'next/server';
+// import { SquareClient, SquareEnvironment } from 'square';
+// import { randomUUID, createHash } from 'crypto';
+
+// type MoneyLike = {
+// 	amount: bigint;
+// 	currency: string;
+// };
+
+// type Summary = {
+// 	processed: number;
+// 	eligible: number;
+// 	charged: number;
+// 	skipped: string[];
+// 	errors: string[];
+// };
+
+// const NO_SHOW_FEE_RATE = 0.35;
+// const GRACE_PERIOD_HOURS = parseInt(process.env.NO_SHOW_GRACE_PERIOD_HOURS || '24', 10);
+// const GRACE_PERIOD_MS = GRACE_PERIOD_HOURS * 60 * 60 * 1000;
+// const LOOKBACK_DAYS = parseInt(process.env.NO_SHOW_LOOKBACK_DAYS || '30', 10);
+// const LOOKBACK_MS = LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+
+// function toBigInt(value: unknown): bigint {
+// 	if (typeof value === 'bigint') {
+// 		return value;
+// 	}
+// 	if (typeof value === 'number') {
+// 		return BigInt(Math.round(value));
+// 	}
+// 	if (typeof value === 'string') {
+// 		return BigInt(value);
+// 	}
+// 	throw new Error(`Unable to convert value "${String(value)}" to BigInt.`);
+// }
+
+// function getVehicleSquareEnvironment(): SquareEnvironment {
+// 	return process.env.SQUARE_ENVIRONMENT === 'production' ? SquareEnvironment.Production : SquareEnvironment.Sandbox;
+// }
+
+// function buildPaymentIdempotencyKey(bookingId: string | undefined, amount: bigint): string {
+// 	const base = `${bookingId || 'unknown'}-${amount.toString()}`;
+// 	return createHash('sha256').update(base).digest('hex').slice(0, 45);
+// }
+
+// function formatMoney(money: MoneyLike | null): string {
+// 	if (!money) {
+// 		return '0.00';
+// 	}
+// 	const amountNumber = Number(money.amount) / 100;
+// 	return `${amountNumber.toFixed(2)} ${money.currency}`;
+// }
+
+// function extractCardId(note: string | null | undefined): string | null {
+// 	const details = getSellerNoteDetails(note);
+// 	if (details.cardId) {
+// 		return details.cardId;
+// 	}
+// 	if (typeof note !== 'string') {
+// 		return null;
+// 	}
+// 	const match = note.match(/Card ID:\s*([\w:-]+)/i);
+// 	return match ? match[1] : null;
+// }
+
+// function getSellerNoteDetails(note: string | null | undefined) {
+// 	const details = {
+// 		cardId: null as string | null,
+// 		chargedCents: null as bigint | null,
+// 		chargedCurrency: null as string | null,
+// 		chargedAt: null as string | null,
+// 		paymentId: null as string | null,
+// 		otherTokens: [] as string[],
+// 	};
+
+// 	if (typeof note !== 'string' || note.trim() === '') {
+// 		return details;
+// }
+
+// 	const tokens = note
+// 		.split('|')
+// 		.map((token) => token.trim())
+// 		.filter(Boolean);
+
+// 	for (const token of tokens) {
+// 		const [rawKey, ...rawValue] = token.split(':');
+// 		if (!rawKey || rawValue.length === 0) {
+// 			details.otherTokens.push(token);
+// 			continue;
+// 		}
+
+// 		const key = rawKey.trim().toLowerCase();
+// 		const value = rawValue.join(':').trim();
+
+// 		switch (key) {
+// 			case 'card id':
+// 				details.cardId = value || null;
+// 				break;
+// 			case 'no-show fee charged (cents)': {
+// 				const numeric = value.replace(/[^0-9-]/g, '');
+// 				if (numeric) {
+// 					try {
+// 						details.chargedCents = BigInt(numeric);
+// 					} catch {
+// 						details.chargedCents = null;
+// 					}
+// 				} else if (value === '0') {
+// 					details.chargedCents = 0n;
+// 				}
+// 				break;
+// 			}
+// 			case 'no-show fee charged currency':
+// 				details.chargedCurrency = value || null;
+// 				break;
+// 			case 'no-show fee charged at':
+// 				details.chargedAt = value || null;
+// 				break;
+// 			case 'no-show fee charged payment id':
+// 				details.paymentId = value || null;
+// 				break;
+// 			default:
+// 				details.otherTokens.push(token);
+// 				break;
+// 		}
+// 	}
+
+// 	return details;
+// }
+
+// function composeChargedSellerNote({
+// 	originalNote,
+// 	cardId,
+// 	feeMoney,
+// 	paymentId,
+// }: {
+// 	originalNote: string | null | undefined;
+// 	cardId: string | null;
+// 	feeMoney: MoneyLike | null;
+// 	paymentId: string | null;
+// }): string {
+// 	const details = getSellerNoteDetails(originalNote);
+// 	const tokens = details.otherTokens.filter(Boolean);
+
+// 	const resolvedCardId = cardId || details.cardId;
+// 	if (resolvedCardId) {
+// 		tokens.unshift(`Card ID: ${resolvedCardId}`);
+// 	}
+
+// 	const amountCents = feeMoney?.amount != null ? feeMoney.amount.toString() : null;
+// 	if (amountCents != null) {
+// 		tokens.push(`No-Show Fee Charged (cents): ${amountCents}`);
+// 	}
+
+// 	if (feeMoney?.currency) {
+// 		tokens.push(`No-Show Fee Charged Currency: ${feeMoney.currency}`);
+// 	} else if (details.chargedCurrency) {
+// 		tokens.push(`No-Show Fee Charged Currency: ${details.chargedCurrency}`);
+// 	}
+
+// 	const chargedAt = new Date().toISOString();
+// 	tokens.push(`No-Show Fee Charged At: ${chargedAt}`);
+
+// 	if (paymentId) {
+// 		tokens.push(`No-Show Fee Charged Payment ID: ${paymentId}`);
+// 	}
+
+// 	return tokens.join(' | ');
+// }
+
+// function calculateNoShowFee(serviceMoney: MoneyLike | null): MoneyLike | null {
+// 	if (!serviceMoney || serviceMoney.amount == null) {
+// 		return null;
+// 	}
+// 	const amountNumber = Number(serviceMoney.amount);
+// 	const feeCents = Math.round(amountNumber * NO_SHOW_FEE_RATE);
+// 	if (feeCents <= 0) {
+// 		return null;
+// 	}
+// 	return {
+// 		amount: BigInt(feeCents),
+// 		currency: serviceMoney.currency || 'USD',
+// 	};
+// }
+
+// function hasGracePeriodElapsed(booking: any): boolean {
+// 	if (!booking?.startAt) {
+// 		return false;
+// 	}
+// 	const startTime = new Date(booking.startAt).getTime();
+// 	if (Number.isNaN(startTime)) {
+// 		return false;
+// 	}
+// 	return startTime + GRACE_PERIOD_MS <= Date.now();
+// }
+
+// function isWithinLookback(booking: any): boolean {
+// 	if (!booking?.startAt) {
+// 		return false;
+// 	}
+// 	const startTime = new Date(booking.startAt).getTime();
+// 	if (Number.isNaN(startTime)) {
+// 		return false;
+// 	}
+// 	return startTime >= Date.now() - LOOKBACK_MS;
+// }
+
+// async function runNoShowFeeJob(): Promise<Summary> {
+// 	const accessToken = process.env.SQUARE_ACCESS_TOKEN;
+// 	if (!accessToken) {
+// 		throw new Error('SQUARE_ACCESS_TOKEN not configured.');
+// 	}
+
+// 	const client = new SquareClient({
+// 		token: accessToken,
+// 		environment: getVehicleSquareEnvironment(),
+// 		userAgentDetail: 'car-wash-no-show-cron-api',
+// 	});
+
+// 	const summary: Summary = {
+// 		processed: 0,
+// 		eligible: 0,
+// 		charged: 0,
+// 		skipped: [],
+// 		errors: [],
+// 	};
+
+// 	const variationPriceCache = new Map<string, MoneyLike>();
+
+// 	function logSkip(bookingId: string | null, reason: string) {
+// 		const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} skipped: ${reason}`;
+// 		summary.skipped.push(message);
+// 		console.log(`⚪ ${message}`);
+// 	}
+
+// 	function logError(bookingId: string | null, error: unknown) {
+// 		const typedError = error as any;
+// 		const errorsList = typedError?.errors?.map((e: any) => e?.detail).filter(Boolean);
+// 		const errorMessage = typedError?.message || (errorsList?.length ? errorsList.join(', ') : null) || String(error);
+// 		const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} failed: ${errorMessage}`;
+// 		summary.errors.push(message);
+// 		console.error(`✗ ${message}`);
+// 	}
+
+// 	async function getLocationId(): Promise<string> {
+// 		const response = await client.locations.list();
+// 		const locations = response?.locations || response?.result?.locations || [];
+// 		if (!locations.length) {
+// 			throw new Error('No Square locations available.');
+// 		}
+// 		return locations[0].id;
+// 	}
+
+// 	async function getVariationPriceMoney(variationId: string | null | undefined): Promise<MoneyLike | null> {
+// 		if (!variationId) {
+// 			return null;
+// 		}
+// 		if (variationPriceCache.has(variationId)) {
+// 			return variationPriceCache.get(variationId) ?? null;
+// 		}
+
+// 		const response = await client.catalog.object.get({ objectId: variationId });
+// 		const variation = response?.object || response?.result?.object || response?.data?.object;
+// 		const priceMoney = variation?.itemVariationData?.priceMoney;
+
+// 		if (!priceMoney || priceMoney.amount == null) {
+// 			throw new Error(`No price found for service variation ${variationId}.`);
+// 		}
+
+// 		const normalized: MoneyLike = {
+// 			amount: toBigInt(priceMoney.amount),
+// 			currency: priceMoney.currency || 'USD',
+// 		};
+// 		variationPriceCache.set(variationId, normalized);
+// 		return normalized;
+// 	}
+
+// 	async function getBookingServicePriceMoney(booking: any): Promise<MoneyLike | null> {
+// 		const segments = Array.isArray(booking?.appointmentSegments) ? booking.appointmentSegments : [];
+// 		if (!segments.length) {
+// 			return null;
+// 		}
+
+// 		let totalAmount = 0n;
+// 		let currency: string | null = null;
+
+// 		for (const segment of segments) {
+// 			const variationId = segment?.serviceVariationId;
+// 			if (!variationId) {
+// 				continue;
+// 			}
+// 			const priceMoney = await getVariationPriceMoney(variationId);
+// 			if (!priceMoney) {
+// 				continue;
+// 			}
+// 			totalAmount += priceMoney.amount;
+// 			currency = currency || priceMoney.currency;
+// 		}
+
+// 		if (totalAmount <= 0n) {
+// 			return null;
+// 		}
+
+// 		return {
+// 			amount: totalAmount,
+// 			currency: currency || 'USD',
+// 		};
+// 	}
+
+// 	async function markBookingCharged({
+// 		booking,
+// 		cardId,
+// 		feeMoney,
+// 		paymentId,
+// 	}: {
+// 		booking: any;
+// 		cardId: string | null;
+// 		feeMoney: MoneyLike;
+// 		paymentId: string | null;
+// 	}) {
+// 		const bookingId = booking?.id;
+// 		if (!bookingId) {
+// 			throw new Error('Cannot update booking without an ID.');
+// 		}
+
+// 		const sellerNote = composeChargedSellerNote({
+// 			originalNote: booking.sellerNote,
+// 			cardId,
+// 			feeMoney,
+// 			paymentId,
+// 		});
+
+// 		const bookingPayload: Record<string, unknown> = {
+// 			sellerNote,
+// 		};
+
+// 		if (booking?.version != null) {
+// 			bookingPayload.version = booking.version;
+// 		}
+
+// 		await client.bookings.update({
+// 			bookingId,
+// 			idempotencyKey: randomUUID(),
+// 			booking: bookingPayload,
+// 		});
+// 	}
+
+// 	async function chargeBooking({
+// 		booking,
+// 		cardId,
+// 		feeMoney,
+// 		locationId,
+// 	}: {
+// 		booking: any;
+// 		cardId: string;
+// 		feeMoney: MoneyLike;
+// 		locationId: string;
+// 	}) {
+// 		const bookingId: string | undefined = booking.id;
+// 		const requestBody = {
+// 			sourceId: cardId,
+// 			idempotencyKey: buildPaymentIdempotencyKey(bookingId, feeMoney.amount),
+// 			amountMoney: feeMoney,
+// 			customerId: booking.customerId || undefined,
+// 			locationId,
+// 			referenceId: bookingId || undefined,
+// 			note: `No-show fee for booking ${bookingId}`,
+// 		};
+
+// 		const response = await client.payments.create(requestBody);
+// 		const payment = response?.payment || response?.result?.payment || response?.data?.payment;
+// 		if (!payment) {
+// 			throw new Error('Payment API response did not include a payment record.');
+// 		}
+
+// 		try {
+// 			await markBookingCharged({ booking, cardId, feeMoney, paymentId: payment.id });
+// 		} catch (error) {
+// 			throw new Error(
+// 				`Charged payment ${payment.id} but failed to update booking note: ${(error as Error)?.message || error}`
+// 			);
+// 		}
+
+// 		console.log(`✅ Charged ${formatMoney(feeMoney)} for booking ${bookingId} (payment ${payment.id}).`);
+// 	}
+
+// 	async function processBookings() {
+// 		const locationId = await getLocationId();
+
+// 		const nowIso = new Date().toISOString();
+// 		const lookbackIso = new Date(Date.now() - LOOKBACK_MS).toISOString();
+
+// 		const bookingsApi: any = (client as any).bookings ?? (client as any).bookingsApi;
+// 		if (!bookingsApi?.list) {
+// 			throw new Error('Square bookings API client is not available.');
+// 		}
+
+// 		const bookingsPage: any = await bookingsApi.list({
+// 			locationId,
+// 			startAtMin: lookbackIso,
+// 			startAtMax: nowIso,
+// 			limit: 100,
+// 		});
+
+// 		for await (const booking of bookingsPage as any) {
+// 			const bookingId: string = booking?.id || 'unknown';
+// 			summary.processed += 1;
+
+// 			if (booking.status !== 'NO_SHOW') {
+// 				logSkip(bookingId, `status ${booking.status}`);
+// 				continue;
+// 			}
+
+// 			if (!isWithinLookback(booking)) {
+// 				logSkip(bookingId, 'outside lookback window');
+// 				continue;
+// 			}
+
+// 			if (!hasGracePeriodElapsed(booking)) {
+// 				logSkip(bookingId, `still within ${GRACE_PERIOD_HOURS}h grace period`);
+// 				continue;
+// 			}
+
+// 			if (!bookingId) {
+// 				logSkip(bookingId, 'missing booking ID');
+// 				continue;
+// 			}
+
+// 			const noteDetails = getSellerNoteDetails(booking.sellerNote);
+// 			const cardId = noteDetails.cardId || extractCardId(booking.sellerNote);
+// 			if (!cardId) {
+// 				logSkip(bookingId, 'no stored card ID found');
+// 				continue;
+// 			}
+
+// 			let serviceMoney: MoneyLike | null = null;
+// 			try {
+// 				serviceMoney = await getBookingServicePriceMoney(booking);
+// 			} catch (error) {
+// 				logError(bookingId, error);
+// 				continue;
+// 			}
+
+// 			if (!serviceMoney) {
+// 				logSkip(bookingId, 'no service price available');
+// 				continue;
+// 			}
+
+// 			const feeMoney = calculateNoShowFee(serviceMoney);
+// 			if (!feeMoney) {
+// 				logSkip(bookingId, 'no-show fee calculated as $0');
+// 				continue;
+// 			}
+
+// 			if (noteDetails.chargedCents != null) {
+// 				const recordedAmount = noteDetails.chargedCents;
+// 				const recordedCurrency = noteDetails.chargedCurrency || feeMoney.currency;
+// 				if (recordedAmount === feeMoney.amount && recordedCurrency === feeMoney.currency) {
+// 					logSkip(bookingId, 'no-show fee already recorded on booking');
+// 					continue;
+// 				}
+
+// 				if (recordedAmount > 0n) {
+// 					logSkip(
+// 						bookingId,
+// 						`booking seller note already shows ${formatMoney({ amount: recordedAmount, currency: recordedCurrency })}`
+// 					);
+// 					continue;
+// 				}
+// 			}
+
+// 			summary.eligible += 1;
+
+// 			try {
+// 				await chargeBooking({ booking, cardId, feeMoney, locationId });
+// 				summary.charged += 1;
+// 			} catch (error) {
+// 				logError(bookingId, error);
+// 			}
+// 		}
+// 	}
+
+// 	console.log('🚀 Starting no-show fee cron run (API invocation)...');
+// 	console.log(`   Grace period: ${GRACE_PERIOD_HOURS} hours | Lookback: ${LOOKBACK_DAYS} days`);
+
+// 	await processBookings();
+
+// 	console.log('––––––––––––––––––––––––––––––––––––');
+// 	console.log(`Processed bookings: ${summary.processed}`);
+// 	console.log(`Eligible for charge: ${summary.eligible}`);
+// 	console.log(`Charged successfully: ${summary.charged}`);
+// 	console.log(`Skipped: ${summary.skipped.length}`);
+// 	console.log(`Errors: ${summary.errors.length}`);
+
+// 	return summary;
+// }
+
+// function getCronSecret(): string | null {
+// 	return process.env.NO_SHOW_CRON_SECRET || process.env.CRON_SECRET || null;
+// }
+
+// function isAuthorized(request: NextRequest): boolean {
+// 	const secret = getCronSecret();
+// 	if (!secret) {
+// 		return true;
+// 	}
+
+// 	const headerSecret = request.headers.get('x-cron-secret') || request.headers.get('authorization');
+// 	if (headerSecret) {
+// 		const token = headerSecret.replace(/^Bearer\s+/i, '').trim();
+// 		return token === secret;
+// 	}
+
+// 	const urlSecret = request.nextUrl.searchParams.get('token') || request.nextUrl.searchParams.get('secret');
+// 	return urlSecret === secret;
+// }
+
+// export async function GET(request: NextRequest) {
+// 	if (!isAuthorized(request)) {
+// 		return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+// 	}
+
+// 	try {
+// 		const summary = await runNoShowFeeJob();
+// 		return NextResponse.json({ ok: true, summary });
+// 	} catch (error) {
+// 		console.error('No-show cron failed', error);
+// 		const typedError = error as any;
+// 		const message = typedError?.message || typedError?.toString?.() || 'Unknown error';
+// 		return NextResponse.json({ ok: false, error: message }, { status: 500 });
+// 	}
+// }
+
+// export const dynamic = 'force-dynamic';

--- a/components/booking/steps/ServiceSelection.tsx
+++ b/components/booking/steps/ServiceSelection.tsx
@@ -14,16 +14,16 @@ import { displayPrice } from '@/lib/utils/currency';
 import { AlertBox } from '@/components/common/AlertBox';
 
 const SERVICES = [
-	{ key: 'interior', name: 'Interior Only', icon: BrushCleaning },
-	{ key: 'exterior', name: 'Exterior Only', icon: Sparkle },
-	{ key: 'full', name: 'Full Detail', icon: Crown },
+	{ key: 'interior-detail-service', name: 'Interior Detail Service', icon: BrushCleaning },
+	{ key: 'exterior-detail-service', name: 'Exterior Detail Service', icon: Sparkle },
+	{ key: 'full-detail-package', name: 'Full Detail Package', icon: Crown },
 ];
 
 const VEHICLES = [
-	{ key: 'car', name: 'Small Car' },
-	{ key: 'new vehicle type', name: 'Small SUV & Small Trucks' },
+	{ key: 'car', name: 'Car' },
+	{ key: 'suv-mini-van', name: 'SUV / Mini Van' },
 	{ key: 'truck', name: 'Truck' },
-	{ key: 'mini van', name: 'Minivan' },
+	{ key: 'small-truck-suv', name: 'Small truck & SUV' },
 ];
 
 const ServiceSelection: React.FC<StepProps> = ({ formData, setFormData }) => {

--- a/contexts/CatalogContext.tsx
+++ b/contexts/CatalogContext.tsx
@@ -48,27 +48,27 @@ export function CatalogProvider({ children }: CatalogProviderProps) {
 
 	const vehicleTypeConfig: Record<string, { label: string; searchTerms: string[] }> = {
 		car: {
-			label: 'Small Car',
-			searchTerms: ['small car', ' - car', ' car'],
+			label: 'Car',
+			searchTerms: ['car', ' - car'],
 		},
-		'new vehicle type': {
-			label: 'Small SUV & Small Trucks',
-			searchTerms: ['small suv & small trucks', 'new vehicle type'],
+		'suv-mini-van': {
+			label: 'SUV / Mini Van',
+			searchTerms: ['suv / mini van', 'suv mini van', 'mini van', 'minivan', 'suv'],
 		},
 		truck: {
 			label: 'Truck',
 			searchTerms: ['truck', ' - truck', 'small truck'],
 		},
-		'mini van': {
-			label: 'Minivan',
-			searchTerms: ['suv / mini van', 'mini van', 'minivan', 'suv'],
+		'small-truck-suv': {
+			label: 'Small truck & SUV',
+			searchTerms: ['small truck & suv', 'small trucks & suv', 'small truck and suv', 'small suv & small truck'],
 		},
 	};
 
 	const serviceTypeKeywordsMap: Record<string, string[]> = {
-		interior: ['interior detail', 'interior only', ' - interior'],
-		exterior: ['exterior detail', 'exterior only', ' - exterior'],
-		full: ['full detail', 'full detail package', 'interior & exterior detail'],
+		'interior-detail-service': ['interior detail service', 'interior detail', 'interior service', 'interior', ' - interior'],
+		'exterior-detail-service': ['exterior detail service', 'exterior detail', 'exterior service', 'exterior', ' - exterior'],
+		'full-detail-package': ['full detail package', 'full detail', 'full detail service', 'interior & exterior detail'],
 	};
 
 	const matchesVehicleType = (vehicleType: string, comparison: string): boolean => {

--- a/docs/no-show-cron-setup.md
+++ b/docs/no-show-cron-setup.md
@@ -1,0 +1,26 @@
+# No-Show Fee Cron Setup
+
+This document explains how to deploy and run the no-show fee job in Vercel. It assumes the serverless route already exists at `app/api/cron/charge-no-show/route.ts`.
+
+- **Expose the job** as a route in `app/api/cron/charge-no-show/route.ts` (already present in this commit). This route mirrors the CLI script’s logic and returns a JSON summary.
+- **Protect the route** with `NO_SHOW_CRON_SECRET` (or reuse `CRON_SECRET`). Vercel will send this token as the `Authorization` or `x-cron-secret` header, preventing public access.
+- **Set Square credentials** in Vercel’s environment: `SQUARE_ACCESS_TOKEN`, `SQUARE_ENVIRONMENT`, `NO_SHOW_GRACE_PERIOD_HOURS`, `NO_SHOW_LOOKBACK_DAYS`, and `NO_SHOW_CRON_SECRET`. Remember to expose them in the “Production” environment (and preview if you test there).
+- **Add a cron entry** to `vercel.json`. Example below runs daily at 8:00 am PT (converted to UTC):
+
+  ```json
+  {
+    "crons": [
+      {
+        "path": "/api/cron/charge-no-show",
+        "schedule": "0 15 * * *"
+      }
+    ]
+  }
+  ```
+  Update the schedule to your preferred time. Cron uses UTC.
+- **Redeploy** so Vercel picks up the cron definition and environment variables. Confirm in the deployment logs that cron is registered.
+- **Manual trigger:** run locally or with `curl` to confirm it works before relying on cron:
+  ```bash
+  curl -H "x-cron-secret: $NO_SHOW_CRON_SECRET" https://<your-vercel-app>/api/cron/charge-no-show
+  ```
+  Expect a JSON response summarizing processed bookings, charges, and errors.

--- a/lib/utils/booking.ts
+++ b/lib/utils/booking.ts
@@ -26,9 +26,9 @@ export const getDurationInHours = (serviceType: string, vehicleType: string): nu
   
   // Default durations matching server-cache.js defaults
   const defaults: Record<string, Record<string, number>> = {
-    'interior': { 'small': 3.5, 'truck': 4.5, 'minivan': 5 },
-    'exterior': { 'small': 3, 'truck': 3.5, 'minivan': 3.5 },
-    'full': { 'small': 4, 'truck': 5, 'minivan': 5.5 }
+    'interior-detail-service': { 'car': 3.5, 'truck': 4.5, 'suv-mini-van': 5, 'small-truck-suv': 4.5 },
+    'exterior-detail-service': { 'car': 3, 'truck': 3.5, 'suv-mini-van': 3.5, 'small-truck-suv': 3.5 },
+    'full-detail-package': { 'car': 4, 'truck': 5, 'suv-mini-van': 5.5, 'small-truck-suv': 5 }
   };
   
   return defaults[serviceType]?.[vehicleType] || 4;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "view:catalog": "node scripts/view-catalog.js",
     "view:team": "node scripts/view-team.js",
     "view:bookings": "node scripts/seed-bookings.js list",
-    "seed:bookings": "node scripts/seed-bookings.js create"
+    "seed:bookings": "node scripts/seed-bookings.js create",
+    "cron:no-show": "node scripts/charge-no-show-fees.js"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/scripts/charge-no-show-fees.js
+++ b/scripts/charge-no-show-fees.js
@@ -1,0 +1,471 @@
+#!/usr/bin/env node
+
+/**
+ * Daily cron job to charge 35% no-show fees for missed appointments.
+ *
+ * The script looks for bookings marked as NO_SHOW that are at least 24 hours old,
+ * charges the saved card on file for 35% of the service price, and writes a
+ * marker into the booking seller note so we do not bill the same booking twice.
+ */
+
+const { config } = require('dotenv');
+const { SquareClient, SquareEnvironment } = require('square');
+const { randomUUID, createHash } = require('crypto');
+
+config({ path: '.env.local' });
+
+const accessToken = process.env.SQUARE_ACCESS_TOKEN;
+if (!accessToken) {
+  console.error('❌ SQUARE_ACCESS_TOKEN not found in .env.local. Aborting no-show cron run.');
+  process.exit(1);
+}
+
+const environment = process.env.SQUARE_ENVIRONMENT === 'production'
+  ? SquareEnvironment.Production
+  : SquareEnvironment.Sandbox;
+
+const client = new SquareClient({
+  token: accessToken,
+  environment,
+  userAgentDetail: 'car-wash-no-show-cron'
+});
+
+const NO_SHOW_FEE_RATE = 0.35;
+const GRACE_PERIOD_HOURS = parseInt(process.env.NO_SHOW_GRACE_PERIOD_HOURS || '24', 10);
+const GRACE_PERIOD_MS = GRACE_PERIOD_HOURS * 60 * 60 * 1000;
+const LOOKBACK_DAYS = parseInt(process.env.NO_SHOW_LOOKBACK_DAYS || '30', 10);
+const LOOKBACK_MS = LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+
+const summary = {
+  processed: 0,
+  eligible: 0,
+  charged: 0,
+  skipped: [],
+  errors: []
+};
+
+const variationPriceCache = new Map();
+
+function logSkip(bookingId, reason) {
+  const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} skipped: ${reason}`;
+  summary.skipped.push(message);
+  console.log(`⚪ ${message}`);
+}
+
+function logError(bookingId, error) {
+  const errorMessage = error?.message || error?.errors?.map(e => e.detail).join(', ') || String(error);
+  const message = `${bookingId ? `Booking ${bookingId}` : 'Booking'} failed: ${errorMessage}`;
+  summary.errors.push(message);
+  console.error(`✗ ${message}`);
+}
+
+async function getLocationId() {
+  const response = await client.locations.list();
+  const locations = response?.locations || response?.result?.locations || [];
+  if (!locations.length) {
+    throw new Error('No Square locations available.');
+  }
+  return locations[0].id;
+}
+
+function toBigInt(value) {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return BigInt(Math.round(value));
+  }
+  if (typeof value === 'string') {
+    return BigInt(value);
+  }
+  throw new Error(`Unable to convert value "${value}" to BigInt.`);
+}
+
+async function getVariationPriceMoney(variationId) {
+  if (!variationId) {
+    return null;
+  }
+  if (variationPriceCache.has(variationId)) {
+    return variationPriceCache.get(variationId);
+  }
+
+  const response = await client.catalog.object.get({ objectId: variationId });
+  const variation = response?.object || response?.result?.object || response?.data?.object;
+  const priceMoney = variation?.itemVariationData?.priceMoney;
+
+  if (!priceMoney || priceMoney.amount == null) {
+    throw new Error(`No price found for service variation ${variationId}.`);
+  }
+
+  const normalized = {
+    amount: toBigInt(priceMoney.amount),
+    currency: priceMoney.currency || 'USD'
+  };
+  variationPriceCache.set(variationId, normalized);
+  return normalized;
+}
+
+async function getBookingServicePriceMoney(booking) {
+  const segments = Array.isArray(booking?.appointmentSegments) ? booking.appointmentSegments : [];
+  if (!segments.length) {
+    return null;
+  }
+
+  let totalAmount = 0n;
+  let currency = null;
+
+  for (const segment of segments) {
+    const variationId = segment?.serviceVariationId;
+    if (!variationId) {
+      continue;
+    }
+    const priceMoney = await getVariationPriceMoney(variationId);
+    totalAmount += priceMoney.amount;
+    currency = currency || priceMoney.currency;
+  }
+
+  if (totalAmount <= 0n) {
+    return null;
+  }
+
+  return {
+    amount: totalAmount,
+    currency: currency || 'USD'
+  };
+}
+
+function calculateNoShowFee(serviceMoney) {
+  if (!serviceMoney || serviceMoney.amount == null) {
+    return null;
+  }
+  const amountNumber = Number(serviceMoney.amount);
+  const feeCents = Math.round(amountNumber * NO_SHOW_FEE_RATE);
+  if (feeCents <= 0) {
+    return null;
+  }
+  return {
+    amount: BigInt(feeCents),
+    currency: serviceMoney.currency || 'USD'
+  };
+}
+
+function formatMoney(money) {
+  if (!money) {
+    return '0.00';
+  }
+  const amountNumber = Number(money.amount) / 100;
+  return `${amountNumber.toFixed(2)} ${money.currency}`;
+}
+
+function extractCardId(note) {
+  const details = getSellerNoteDetails(note);
+  if (details.cardId) {
+    return details.cardId;
+  }
+  if (typeof note !== 'string') {
+    return null;
+  }
+  const match = note.match(/Card ID:\s*([\w:-]+)/i);
+  return match ? match[1] : null;
+}
+
+function getSellerNoteDetails(note) {
+  const details = {
+    cardId: null,
+    chargedCents: null,
+    chargedCurrency: null,
+    chargedAt: null,
+    paymentId: null,
+    otherTokens: []
+  };
+
+  if (typeof note !== 'string' || note.trim() === '') {
+    return details;
+  }
+
+  const tokens = note.split('|').map(token => token.trim()).filter(Boolean);
+  for (const token of tokens) {
+    const [rawKey, ...rawValue] = token.split(':');
+    if (!rawKey || rawValue.length === 0) {
+      details.otherTokens.push(token);
+      continue;
+    }
+
+    const key = rawKey.trim().toLowerCase();
+    const value = rawValue.join(':').trim();
+
+    switch (key) {
+      case 'card id':
+        details.cardId = value || null;
+        break;
+      case 'no-show fee charged (cents)': {
+        const numeric = value.replace(/[^0-9-]/g, '');
+        if (numeric) {
+          try {
+            details.chargedCents = BigInt(numeric);
+          } catch {
+            details.chargedCents = null;
+          }
+        } else if (value === '0') {
+          details.chargedCents = 0n;
+        }
+        break;
+      }
+      case 'no-show fee charged currency':
+        details.chargedCurrency = value || null;
+        break;
+      case 'no-show fee charged at':
+        details.chargedAt = value || null;
+        break;
+      case 'no-show fee charged payment id':
+        details.paymentId = value || null;
+        break;
+      default:
+        details.otherTokens.push(token);
+        break;
+    }
+  }
+
+  return details;
+}
+
+function composeChargedSellerNote({ originalNote, cardId, feeMoney, paymentId }) {
+  const details = getSellerNoteDetails(originalNote);
+  const tokens = details.otherTokens.filter(Boolean);
+
+  const resolvedCardId = cardId || details.cardId;
+  if (resolvedCardId) {
+    tokens.unshift(`Card ID: ${resolvedCardId}`);
+  }
+
+  const amountCents = feeMoney?.amount != null ? feeMoney.amount.toString() : null;
+  if (amountCents != null) {
+    tokens.push(`No-Show Fee Charged (cents): ${amountCents}`);
+  }
+
+  if (feeMoney?.currency) {
+    tokens.push(`No-Show Fee Charged Currency: ${feeMoney.currency}`);
+  } else if (details.chargedCurrency) {
+    tokens.push(`No-Show Fee Charged Currency: ${details.chargedCurrency}`);
+  }
+
+  const chargedAt = new Date().toISOString();
+  tokens.push(`No-Show Fee Charged At: ${chargedAt}`);
+
+  if (paymentId) {
+    tokens.push(`No-Show Fee Charged Payment ID: ${paymentId}`);
+  }
+
+  return tokens.join(' | ');
+}
+
+function buildPaymentIdempotencyKey(bookingId, amount) {
+  const base = `${bookingId || 'unknown'}-${amount != null ? amount.toString() : '0'}`;
+  return createHash('sha256').update(base).digest('hex').slice(0, 45);
+}
+
+async function markBookingCharged({ booking, cardId, feeMoney, paymentId }) {
+  const bookingId = booking?.id;
+  if (!bookingId) {
+    throw new Error('Cannot update booking without an ID.');
+  }
+
+  const sellerNote = composeChargedSellerNote({
+    originalNote: booking.sellerNote,
+    cardId,
+    feeMoney,
+    paymentId
+  });
+
+  const bookingPayload = {
+    sellerNote
+  };
+
+  if (booking?.version != null) {
+    bookingPayload.version = booking.version;
+  }
+
+  await client.bookings.update({
+    bookingId,
+    idempotencyKey: randomUUID(),
+    booking: bookingPayload
+  });
+}
+
+function hasGracePeriodElapsed(booking) {
+  if (!booking?.startAt) {
+    return false;
+  }
+  const startTime = new Date(booking.startAt).getTime();
+  if (Number.isNaN(startTime)) {
+    return false;
+  }
+  return startTime + GRACE_PERIOD_MS <= Date.now();
+}
+
+function isWithinLookback(booking) {
+  if (!booking?.startAt) {
+    return false;
+  }
+  const startTime = new Date(booking.startAt).getTime();
+  if (Number.isNaN(startTime)) {
+    return false;
+  }
+  return startTime >= Date.now() - LOOKBACK_MS;
+}
+
+async function chargeBooking({ booking, cardId, feeMoney, locationId }) {
+  const bookingId = booking.id;
+  const requestBody = {
+    sourceId: cardId,
+    idempotencyKey: buildPaymentIdempotencyKey(bookingId, feeMoney.amount),
+    amountMoney: feeMoney,
+    customerId: booking.customerId || undefined,
+    locationId,
+    referenceId: bookingId || undefined,
+    note: `No-show fee for booking ${bookingId}`
+  };
+
+  const response = await client.payments.create(requestBody);
+  const payment = response?.payment || response?.result?.payment || response?.data?.payment;
+  if (!payment) {
+    throw new Error('Payment API response did not include a payment record.');
+  }
+
+  try {
+    await markBookingCharged({ booking, cardId, feeMoney, paymentId: payment.id });
+  } catch (error) {
+    throw new Error(`Charged payment ${payment.id} but failed to update booking note: ${error?.message || error}`);
+  }
+
+  console.log(`✅ Charged ${formatMoney(feeMoney)} for booking ${bookingId} (payment ${payment.id}).`);
+}
+
+async function processBookings() {
+  const locationId = await getLocationId();
+
+  const nowIso = new Date().toISOString();
+  const lookbackIso = new Date(Date.now() - LOOKBACK_MS).toISOString();
+  const bookingsPage = await client.bookings.list({
+    locationId,
+    startAtMin: lookbackIso,
+    startAtMax: nowIso,
+    limit: 100
+  });
+
+  for await (const booking of bookingsPage) {
+    const bookingId = booking?.id || 'unknown';
+    summary.processed += 1;
+
+    if (booking.status !== 'NO_SHOW') {
+      logSkip(bookingId, `status ${booking.status}`);
+      continue;
+    }
+
+    if (!isWithinLookback(booking)) {
+      logSkip(bookingId, 'outside lookback window');
+      continue;
+    }
+
+    if (!hasGracePeriodElapsed(booking)) {
+      logSkip(bookingId, `still within ${GRACE_PERIOD_HOURS}h grace period`);
+      continue;
+    }
+
+    if (!bookingId) {
+      logSkip(bookingId, 'missing booking ID');
+      continue;
+    }
+
+    const noteDetails = getSellerNoteDetails(booking.sellerNote);
+    const cardId = noteDetails.cardId || extractCardId(booking.sellerNote);
+    if (!cardId) {
+      logSkip(bookingId, 'no stored card ID found');
+      continue;
+    }
+
+    let serviceMoney;
+    try {
+      serviceMoney = await getBookingServicePriceMoney(booking);
+    } catch (error) {
+      logError(bookingId, error);
+      continue;
+    }
+
+    if (!serviceMoney) {
+      logSkip(bookingId, 'no service price available');
+      continue;
+    }
+
+    const feeMoney = calculateNoShowFee(serviceMoney);
+    if (!feeMoney) {
+      logSkip(bookingId, 'no-show fee calculated as $0');
+      continue;
+    }
+
+    if (noteDetails.chargedCents != null) {
+      const recordedAmount = noteDetails.chargedCents;
+      const recordedCurrency = noteDetails.chargedCurrency || feeMoney.currency;
+      if (recordedAmount === feeMoney.amount && recordedCurrency === feeMoney.currency) {
+        logSkip(bookingId, 'no-show fee already recorded on booking');
+        continue;
+      }
+
+      if (recordedAmount > 0n) {
+        logSkip(
+          bookingId,
+          `booking seller note already shows ${formatMoney({ amount: recordedAmount, currency: recordedCurrency })}`
+        );
+        continue;
+      }
+    }
+
+    summary.eligible += 1;
+
+    try {
+      await chargeBooking({ booking, cardId, feeMoney, locationId });
+      summary.charged += 1;
+    } catch (error) {
+      logError(bookingId, error);
+    }
+  }
+}
+
+async function main() {
+  console.log('🚀 Starting daily no-show fee cron run...');
+  console.log(`   Grace period: ${GRACE_PERIOD_HOURS} hours | Lookback: ${LOOKBACK_DAYS} days`);
+
+  try {
+    await processBookings();
+  } catch (error) {
+    console.error('❌ Fatal error while processing bookings:', error);
+    process.exit(1);
+  }
+
+  console.log('––––––––––––––––––––––––––––––––––––');
+  console.log(`Processed bookings: ${summary.processed}`);
+  console.log(`Eligible for charge: ${summary.eligible}`);
+  console.log(`Charged successfully: ${summary.charged}`);
+  console.log(`Skipped: ${summary.skipped.length}`);
+  console.log(`Errors: ${summary.errors.length}`);
+
+  if (summary.skipped.length) {
+    console.log('\nSkipped bookings:');
+    for (const message of summary.skipped) {
+      console.log(` • ${message}`);
+    }
+  }
+
+  if (summary.errors.length) {
+    console.log('\nErrors:');
+    for (const message of summary.errors) {
+      console.log(` • ${message}`);
+    }
+  }
+
+  if (summary.errors.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a default "No-Show Fee Charged" marker to new bookings so card metadata tracks future no-show charges
- update the cron job to skip already charged bookings by reading and updating seller notes instead of a local ledger
- refresh documentation and remove the unused data directory to reflect the new persistence approach

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ed1870348325b4275f0ebd08e068