### PR TITLE
Remove upfront payment, implement card-on-file for no-show protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,7 @@ SQUARE_ACCESS_TOKEN=your-square-access-token
 NEXT_PUBLIC_SQUARE_APPLICATION_ID=your-square-application-id
 SQUARE_ENVIRONMENT=sandbox # sandbox | production
 
+# Cron job security (optional - if not set, cron endpoint will be accessible without auth)
+CRON_SECRET=your-secret-token-here
 
 ADMIN_PASSWORD=password # the password to access the dashboard (URL: /admin)

--- a/app/api/cron/no-show-check/route.ts
+++ b/app/api/cron/no-show-check/route.ts
@@ -1,0 +1,158 @@
+import { bookingsApi, cardsApi, customersApi, getLocationId, paymentsApi } from '../../lib/client';
+import { successResponse, handleSquareError } from '../../lib/utils';
+import { randomUUID } from 'crypto';
+
+const NO_SHOW_WINDOW_HOURS = 48;
+
+/**
+ * POST /api/cron/no-show-check
+ *
+ * Cron job endpoint to check for no-show bookings and charge fees.
+ * This should be called every 24 hours by a cron service (e.g., Vercel Cron, GitHub Actions, etc.)
+ *
+ * Process:
+ * 1. Find bookings that started 48+ hours ago
+ * 2. Check if booking status indicates completion or cancellation
+ * 3. For no-shows, extract card ID from seller note
+ * 4. Charge the no-show fee using the card on file
+ */
+export async function POST(request: Request) {
+	try {
+		// Verify this is a legitimate cron request
+		const authHeader = request.headers.get('authorization');
+		const cronSecret = process.env.CRON_SECRET;
+
+		if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+			return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+				status: 401,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+
+		const now = new Date();
+		const noShowCutoff = new Date(now.getTime() - NO_SHOW_WINDOW_HOURS * 60 * 60 * 1000);
+
+		// Query bookings from the past 7 days up to the no-show cutoff
+		const queryStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+		const bookingsResponse = await bookingsApi.list({
+			limit: 100,
+			startAtMin: queryStart.toISOString(),
+			startAtMax: noShowCutoff.toISOString(),
+		});
+
+		const bookings: any[] = [];
+		for await (const booking of bookingsResponse as any) {
+			bookings.push(booking);
+		}
+
+		const noShowBookings: any[] = [];
+		const chargeResults: any[] = [];
+
+		for (const booking of bookings) {
+			// Skip if booking was cancelled or completed
+			if (booking.status === 'CANCELLED' || booking.status === 'COMPLETED' || booking.status === 'ACCEPTED') {
+				continue;
+			}
+
+			// Skip if no seller note (complimentary bookings won't have card info)
+			if (!booking.sellerNote) {
+				continue;
+			}
+
+			// Extract card ID from seller note
+			const cardIdMatch = booking.sellerNote.match(/Card ID: (card_[a-zA-Z0-9_-]+)/);
+			if (!cardIdMatch) {
+				// No card on file, skip
+				continue;
+			}
+
+			const cardId = cardIdMatch[1];
+
+			// Extract service amount from seller note
+			const amountMatch = booking.sellerNote.match(/Service Amount \(cents\): (\d+)/);
+			const currencyMatch = booking.sellerNote.match(/Currency: ([A-Z]{3})/);
+
+			if (!amountMatch || !currencyMatch) {
+				console.error(`Missing amount or currency for booking ${booking.id}`);
+				continue;
+			}
+
+			const amount = BigInt(amountMatch[1]);
+			const currency = currencyMatch[1];
+
+			noShowBookings.push({
+				bookingId: booking.id,
+				customerId: booking.customerId,
+				startAt: booking.startAt,
+				cardId,
+				amount,
+				currency,
+			});
+
+			// Charge the no-show fee
+			try {
+				const defaultLocationId = await getLocationId();
+
+				const paymentResponse = await paymentsApi.create({
+					sourceId: cardId,
+					idempotencyKey: randomUUID(),
+					amountMoney: {
+						amount,
+						currency: currency as any,
+					},
+					customerId: booking.customerId,
+					locationId: defaultLocationId,
+					autocomplete: true,
+					note: `No-show fee for booking ${booking.id} on ${new Date(booking.startAt).toLocaleDateString()}`,
+				});
+
+				if (paymentResponse.errors?.length) {
+					chargeResults.push({
+						bookingId: booking.id,
+						success: false,
+						error: paymentResponse.errors[0]?.detail || 'Failed to charge no-show fee',
+					});
+					console.error(`Failed to charge no-show fee for booking ${booking.id}:`, paymentResponse.errors);
+				} else {
+					chargeResults.push({
+						bookingId: booking.id,
+						success: true,
+						paymentId: paymentResponse.payment?.id,
+						amount: amount.toString(),
+						currency,
+					});
+
+					// Update booking status to indicate payment was charged
+					try {
+						await bookingsApi.update({
+							bookingId: booking.id,
+							booking: {
+								version: booking.version,
+								sellerNote: `${booking.sellerNote} | No-show fee charged: ${paymentResponse.payment?.id}`,
+							},
+						});
+					} catch (updateError) {
+						console.warn(`Failed to update booking ${booking.id} after charging no-show fee:`, updateError);
+					}
+				}
+			} catch (chargeError: any) {
+				chargeResults.push({
+					bookingId: booking.id,
+					success: false,
+					error: chargeError.message || 'Failed to charge no-show fee',
+				});
+				console.error(`Error charging no-show fee for booking ${booking.id}:`, chargeError);
+			}
+		}
+
+		return successResponse({
+			message: 'No-show check completed',
+			noShowBookings: noShowBookings.length,
+			chargeResults,
+			timestamp: now.toISOString(),
+		});
+	} catch (error) {
+		return handleSquareError(error, 'Failed to process no-show check');
+	}
+}

--- a/app/api/cron/no-show-check/route.ts
+++ b/app/api/cron/no-show-check/route.ts
@@ -62,6 +62,11 @@ export async function POST(request: Request) {
 				continue;
 			}
 
+			// Skip if no-show fee has already been charged (prevent duplicate charges)
+			if (booking.sellerNote.includes('No-show fee charged:')) {
+				continue;
+			}
+
 			// Extract card ID from seller note
 			const cardIdMatch = booking.sellerNote.match(/Card ID: (card_[a-zA-Z0-9_-]+)/);
 			if (!cardIdMatch) {

--- a/components/booking/steps/Payment.tsx
+++ b/components/booking/steps/Payment.tsx
@@ -141,7 +141,7 @@ const Payment: React.FC<StepProps> = ({ formData, setFormData }) => {
                 <p className="mb-2">Your card will be securely stored but not charged at booking.</p>
                 <ul className="space-y-1">
                   <li>• <strong>Pay at service:</strong> {paymentAmountLabel}</li>
-                  <li>• <strong>No-show fee:</strong> Full service amount charged if you miss your appointment without 24hr notice</li>
+                  <li>• <strong>No-show fee:</strong> 30% of service amount charged if you miss your appointment without 24hr notice</li>
                   <li>• Card information processed securely by Square</li>
                 </ul>
               </div>

--- a/components/booking/steps/Payment.tsx
+++ b/components/booking/steps/Payment.tsx
@@ -131,18 +131,18 @@ const Payment: React.FC<StepProps> = ({ formData, setFormData }) => {
             message="This booking is complimentary, so you won't be charged or asked to enter card details."
           />
         ) : (
-          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
             <div className="flex items-start">
-              <svg className="w-5 h-5 text-amber-600 mt-0.5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              <svg className="w-5 h-5 text-blue-600 mt-0.5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
               </svg>
-              <div className="text-sm text-amber-800">
-                <p className="font-semibold mb-1">Secure Your Appointment</p>
-                <p className="mb-2">We charge your card now to guarantee your detailing slot.</p>
+              <div className="text-sm text-blue-800">
+                <p className="font-semibold mb-1">Card on File for No-Show Protection</p>
+                <p className="mb-2">Your card will be securely stored but not charged at booking.</p>
                 <ul className="space-y-1">
-                  <li>• Total charged today: <strong>{paymentAmountLabel}</strong></li>
-                  <li>• Free reschedule/cancellation with 24 hours notice</li>
-                  <li>• Payments processed securely by Square</li>
+                  <li>• <strong>Pay at service:</strong> {paymentAmountLabel}</li>
+                  <li>• <strong>No-show fee:</strong> Full service amount charged if you miss your appointment without 24hr notice</li>
+                  <li>• Card information processed securely by Square</li>
                 </ul>
               </div>
             </div>
@@ -158,7 +158,7 @@ const Payment: React.FC<StepProps> = ({ formData, setFormData }) => {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <span className="text-green-800 font-medium">
-                  {formData.cardBrand} ending in {formData.cardLastFour} ready for booking charge
+                  {formData.cardBrand} ending in {formData.cardLastFour} will be saved on file
                 </span>
               </div>
               <button
@@ -240,14 +240,14 @@ const Payment: React.FC<StepProps> = ({ formData, setFormData }) => {
             </div>
           </div>
         ) : (
-          <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
             <div className="flex items-center">
-              <svg className="w-5 h-5 text-green-600 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 text-blue-600 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
               </svg>
-              <div className="text-sm text-green-800">
-                <p className="font-semibold">{paymentAmountLabel} will be charged when you confirm your booking</p>
-                <p className="text-xs text-green-700 mt-1">You&apos;ll receive an email receipt from Square right away.</p>
+              <div className="text-sm text-blue-800">
+                <p className="font-semibold">Your card will be saved when you confirm your booking</p>
+                <p className="text-xs text-blue-700 mt-1">You&apos;ll pay {paymentAmountLabel} when you arrive for service.</p>
               </div>
             </div>
           </div>

--- a/components/booking/steps/ReviewConfirm.tsx
+++ b/components/booking/steps/ReviewConfirm.tsx
@@ -196,7 +196,7 @@ const ReviewConfirm: React.FC<StepProps> = ({ formData }) => {
           <AlertBox
             variant="info"
             title="Payment Policy"
-            message="Your card is secured for no-show protection only. You'll pay at service. If you miss your appointment without 24 hours notice, the full service amount will be charged to your card on file."
+            message="Your card is secured for no-show protection only. You'll pay at service. If you miss your appointment without 24 hours notice, a 30% no-show fee will be charged to your card on file."
           />
         ) : (
           <AlertBox

--- a/components/booking/steps/ReviewConfirm.tsx
+++ b/components/booking/steps/ReviewConfirm.tsx
@@ -132,7 +132,7 @@ const ReviewConfirm: React.FC<StepProps> = ({ formData }) => {
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-600">Charge Timing:</span>
-                  <span className="font-medium text-green-600">Charged immediately when you confirm</span>
+                  <span className="font-medium text-blue-600">Pay at service (card on file for no-shows)</span>
                 </div>
               </>
             ) : (
@@ -161,7 +161,7 @@ const ReviewConfirm: React.FC<StepProps> = ({ formData }) => {
             <div className="relative">
               <div className="flex justify-between items-start mb-4">
                 <div>
-                  <p className="text-brand-100 text-sm font-medium mb-1">{requiresPayment ? 'Service Total (Paid Today)' : 'Service Total'}</p>
+                  <p className="text-brand-100 text-sm font-medium mb-1">{requiresPayment ? 'Service Total (Pay at Service)' : 'Service Total'}</p>
                   <div className="flex items-baseline">
                     <span className="text-4xl font-bold text-white">
                       {displayPrice(estimatedPrice)}
@@ -180,10 +180,10 @@ const ReviewConfirm: React.FC<StepProps> = ({ formData }) => {
                     <svg className="w-5 h-5 text-brand-200 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
-                    <p className="text-sm text-brand-100">{requiresPayment ? 'Charged online via Square when you confirm' : 'Complimentary appointment – no payment will be collected'}</p>
+                    <p className="text-sm text-brand-100">{requiresPayment ? 'Card secured for no-show protection – pay at service' : 'Complimentary appointment – no payment will be collected'}</p>
                   </div>
                   <span className="px-3 py-1 bg-white/20 rounded-full text-xs font-medium text-white">
-                    {requiresPayment ? 'Digital Receipt' : 'Complimentary'}
+                    {requiresPayment ? 'Card on File' : 'Complimentary'}
                   </span>
                 </div>
               </div>
@@ -196,7 +196,7 @@ const ReviewConfirm: React.FC<StepProps> = ({ formData }) => {
           <AlertBox
             variant="info"
             title="Payment Policy"
-            message="Your card is charged immediately to hold your appointment. Need to reschedule? Contact us at least 24 hours in advance for a full refund."
+            message="Your card is secured for no-show protection only. You'll pay at service. If you miss your appointment without 24 hours notice, the full service amount will be charged to your card on file."
           />
         ) : (
           <AlertBox

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "view:team": "node scripts/view-team.js",
     "view:bookings": "node scripts/seed-bookings.js list",
     "seed:bookings": "node scripts/seed-bookings.js create",
-    "set:prices-zero": "node scripts/set-prices-to-zero.js"
+    "set:prices-zero": "node scripts/set-prices-to-zero.js",
+    "set:original-prices": "node scripts/set-original-prices.js"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/scripts/set-original-prices.js
+++ b/scripts/set-original-prices.js
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+
+/**
+ * Set all item variation prices to original prices from flyer
+ * Usage: node scripts/set-original-prices.js
+ */
+
+import { randomUUID } from 'crypto';
+import { SquareClient, SquareEnvironment } from 'square';
+import { config } from 'dotenv';
+
+// Load environment variables
+config({ path: '.env.local' });
+
+// Initialize Square client
+const accessToken = process.env.SQUARE_ACCESS_TOKEN;
+if (!accessToken) {
+  console.error('❌ SQUARE_ACCESS_TOKEN not found in .env.local');
+  process.exit(1);
+}
+
+const environment = process.env.SQUARE_ENVIRONMENT === 'production' 
+  ? SquareEnvironment.Production 
+  : SquareEnvironment.Sandbox;
+
+const client = new SquareClient({
+  token: accessToken,
+  environment,
+  userAgentDetail: 'set-original-prices'
+});
+
+/**
+ * Price mapping based on the flyer
+ * Prices are in dollars, will be converted to cents (BigInt)
+ */
+const PRICE_MAP = {
+  // Interior Detail Service
+  'Interior Detail Service - Car': 21000, // $210.00
+  'Interior Detail Service - SUV / Mini Van': 26500, // $265.00
+  'Interior Detail Service - Truck': 25000, // $250.00
+  'Small truck & SUV - Interior': 22000, // $220.00
+  
+  // Exterior Detail Service
+  'Exterior Detail Service - Car': 21000, // $210.00
+  'Exterior Detail Service - SUV / Mini Van': 25000, // $250.00
+  'Exterior Detail Service - Truck': 25000, // $250.00
+  'Small trucks & SUV - Exterior': 22000, // $220.00
+  
+  // Full Detail Package
+  'Full Detail Package - Car': 29500, // $295.00
+  'Full Detail Package - SUV / Mini Van': 36500, // $365.00
+  'Full Detail Package - Truck': 35000, // $350.00
+  'Small truck & SUV - Full Detail': 32000, // $320.00
+};
+
+/**
+ * Get price for a service item based on its name
+ */
+function getPriceForItem(itemName) {
+  // Try exact match first
+  if (PRICE_MAP[itemName]) {
+    return PRICE_MAP[itemName];
+  }
+  
+  // Try case-insensitive match
+  const normalizedName = Object.keys(PRICE_MAP).find(
+    key => key.toLowerCase() === itemName.toLowerCase()
+  );
+  
+  if (normalizedName) {
+    return PRICE_MAP[normalizedName];
+  }
+  
+  return null;
+}
+
+/**
+ * Retrieve all catalog variations directly
+ */
+async function getAllCatalogVariations() {
+  try {
+    console.log('📋 Fetching catalog variations from Square...');
+    
+    const response = await client.catalog.search({
+      objectTypes: ['ITEM_VARIATION'],
+      includeDeletedObjects: false,
+    });
+    
+    const variations = response.objects || [];
+    console.log(`✓ Found ${variations.length} catalog variations`);
+    
+    return variations;
+  } catch (error) {
+    console.error('❌ Failed to fetch catalog variations:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Retrieve all catalog items for price mapping
+ */
+async function getAllCatalogItems() {
+  try {
+    const response = await client.catalog.search({
+      objectTypes: ['ITEM'],
+      includeDeletedObjects: false,
+    });
+    
+    return response.objects || [];
+  } catch (error) {
+    console.error('❌ Failed to fetch catalog items:', error.message);
+    return [];
+  }
+}
+
+/**
+ * Prepare variation update objects with original prices
+ */
+function prepareVariationUpdates(variations, items) {
+  const variationsToUpdate = [];
+  const itemsMap = new Map();
+  
+  // Create a map of item IDs to item names for quick lookup
+  items.forEach(item => {
+    if (item.id && item.itemData?.name) {
+      itemsMap.set(item.id, item.itemData.name);
+    }
+  });
+  
+  for (const variation of variations) {
+    if (!variation.itemVariationData?.itemId) {
+      continue;
+    }
+    
+    const itemId = variation.itemVariationData.itemId;
+    const itemName = itemsMap.get(itemId);
+    
+    if (!itemName) {
+      console.warn(`⚠️  Could not find item name for variation ${variation.id}`);
+      continue;
+    }
+    
+    const priceInCents = getPriceForItem(itemName);
+    
+    if (priceInCents === null) {
+      console.warn(`⚠️  No price mapping found for: "${itemName}"`);
+      continue;
+    }
+    
+    variationsToUpdate.push({
+      type: 'ITEM_VARIATION',
+      id: variation.id,
+      version: variation.version, // Required for optimistic locking
+      presentAtAllLocations: variation.presentAtAllLocations ?? true,
+      itemVariationData: {
+        itemId: variation.itemVariationData.itemId,
+        name: variation.itemVariationData.name,
+        sku: variation.itemVariationData.sku,
+        availableForBooking: variation.itemVariationData.availableForBooking ?? true,
+        pricingType: 'FIXED_PRICING',
+        priceMoney: {
+          amount: BigInt(priceInCents), // Convert dollars to cents
+          currency: variation.itemVariationData.priceMoney?.currency || 'USD',
+        },
+        serviceDuration: variation.itemVariationData.serviceDuration,
+      },
+    });
+  }
+  
+  return variationsToUpdate;
+}
+
+/**
+ * Update all variations using batch upsert
+ */
+async function updateVariations(variations) {
+  if (variations.length === 0) {
+    console.log('⚠️  No variations found to update');
+    return;
+  }
+  
+  console.log(`\n🔄 Updating ${variations.length} item variations...`);
+  
+  // Square API has a limit on batch size, so we'll process in batches of 100
+  const batchSize = 100;
+  let updatedCount = 0;
+  let failedCount = 0;
+  const failedVariations = [];
+  
+  for (let i = 0; i < variations.length; i += batchSize) {
+    const batch = variations.slice(i, i + batchSize);
+    const batchNumber = Math.floor(i / batchSize) + 1;
+    
+    console.log(`  Processing batch ${batchNumber} (${batch.length} variations)...`);
+    
+    try {
+      const response = await client.catalog.batchUpsert({
+        idempotencyKey: randomUUID(),
+        batches: [
+          {
+            objects: batch,
+          },
+        ],
+      });
+      
+      if (response.errors && response.errors.length > 0) {
+        console.error(`  ⚠️  Some errors occurred in batch ${batchNumber}:`);
+        response.errors.forEach((error, idx) => {
+          const variation = batch[idx] || { id: 'unknown' };
+          console.error(`    - ${variation.id}: ${error.code} - ${error.detail}`);
+          failedVariations.push({ variation: variation.id, error: error.detail });
+          failedCount++;
+        });
+        // Count successful ones
+        updatedCount += batch.length - response.errors.length;
+      } else {
+        updatedCount += batch.length;
+        console.log(`  ✓ Successfully updated ${batch.length} variations`);
+      }
+    } catch (error) {
+      console.error(`  ❌ Failed to process batch ${batchNumber}:`, error.message);
+      if (error.errors) {
+        error.errors.forEach(err => {
+          console.error(`    - ${err.code}: ${err.detail}`);
+        });
+      }
+      // Mark all in this batch as failed
+      failedCount += batch.length;
+      batch.forEach(v => {
+        failedVariations.push({ variation: v.id, error: error.message });
+      });
+    }
+  }
+  
+  console.log(`\n📊 Summary:`);
+  console.log(`   ✅ Successfully updated: ${updatedCount} variations`);
+  if (failedCount > 0) {
+    console.log(`   ❌ Failed: ${failedCount} variations`);
+  }
+  
+  if (failedVariations.length > 0) {
+    console.log(`\n⚠️  Failed variations:`);
+    failedVariations.forEach(({ variation, error }) => {
+      console.log(`   - ${variation}: ${error}`);
+    });
+  }
+}
+
+/**
+ * Format price for display
+ */
+function formatPrice(cents) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  console.log('💰 Set All Item Variation Prices to Original Prices');
+  console.log(`🔧 Environment: ${environment === SquareEnvironment.Sandbox ? 'Sandbox' : 'Production'}`);
+  console.log('━'.repeat(50));
+  
+  try {
+    // Get all catalog variations
+    const variations = await getAllCatalogVariations();
+    
+    // Get items for price mapping
+    const items = await getAllCatalogItems();
+    
+    // Prepare variation updates
+    const variationsToUpdate = prepareVariationUpdates(variations, items);
+    
+    console.log(`\n📊 Summary:`);
+    console.log(`   Total variations found: ${variations.length}`);
+    console.log(`   Variations to update: ${variationsToUpdate.length}`);
+    
+    if (variationsToUpdate.length === 0) {
+      console.log('\n⚠️  No variations found with price mappings. Nothing to update.');
+      return;
+    }
+    
+    // Show what will be updated
+    console.log('\n📝 Variations that will be updated:');
+    const itemsMap = new Map();
+    items.forEach(item => {
+      if (item.id && item.itemData?.name) {
+        itemsMap.set(item.id, item.itemData.name);
+      }
+    });
+    
+    for (const variation of variationsToUpdate) {
+      const itemId = variation.itemVariationData.itemId;
+      const itemName = itemsMap.get(itemId) || 'Unknown';
+      const priceInCents = getPriceForItem(itemName);
+      console.log(`   - ${itemName} > ${variation.itemVariationData.name}: ${formatPrice(priceInCents)}`);
+    }
+    
+    // Confirm before proceeding
+    console.log('\n⚠️  WARNING: This will update all variation prices to original flyer prices');
+    console.log('   Press Ctrl+C to cancel, or wait 3 seconds to continue...');
+    
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    
+    // Update variations
+    await updateVariations(variationsToUpdate);
+    
+    console.log('\n✨ Done!');
+  } catch (error) {
+    console.error('\n❌ Fatal error:', error.message);
+    if (error.errors) {
+      error.errors.forEach(err => {
+        console.error(`  - ${err.code}: ${err.detail}`);
+      });
+    }
+    process.exit(1);
+  }
+}
+
+// Run the script
+main();
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/no-show-check",
+      "schedule": "0 0 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Changes:
- Modified booking API to store card on file instead of charging immediately
- Customers now pay at service, not at booking time
- Added cron job to check for no-shows (48h after booking) and charge no-show fee
- Updated Payment step UI to reflect card-on-file model
- Updated ReviewConfirm step to show "Pay at Service" instead of "Paid Today"
- Added vercel.json for cron job configuration (runs daily at midnight UTC)
- Updated .env.example to include CRON_SECRET for cron endpoint security

Technical details:
- Using Square Cards API to create card on file
- Card ID stored in booking seller note for later retrieval
- Cron endpoint at /api/cron/no-show-check processes missed appointments
- No-show window set to 48 hours after booking start time

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces upfront charges with card-on-file, adds a cron to bill no-show fees, and updates UI and config accordingly.
> 
> - **Backend**
>   - **Booking API (`app/api/bookings/route.ts`)**: Replace immediate payment with storing card on file via `cardsApi.create`; record `Card ID`, service amount, and currency in `sellerNote`; adjust customer notes to "pay at service"; add `deleteCardOnFile`; remove payment authorization/void flows.
>   - **Cron (`app/api/cron/no-show-check/route.ts`)**: New POST endpoint to find `ACCEPTED` bookings older than 48h, extract `Card ID` and price from `sellerNote`, charge 30% no-show fee via Payments API, and append result to `sellerNote`; supports `CRON_SECRET` bearer auth.
> - **Frontend**
>   - **Payment/Review steps**: Update copy and indicators to "Card on file" and "Pay at service"; show saved card details.
> - **Ops/Config**
>   - Add `vercel.json` daily cron schedule for `/api/cron/no-show-check`.
>   - `.env.example`: add `CRON_SECRET` for securing the cron endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665afbd5da107633d715518ae18a0635b2050aa8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->